### PR TITLE
fix: remove error comments that pollute output

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -15,8 +15,7 @@ export const FormatTables: Plugin = async () => {
       try {
         output.text = formatMarkdownTables(output.text)
       } catch (error) {
-        // If formatting fails, keep original md text
-        output.text = output.text + "\n\n<!-- table formatting failed: " + (error as Error).message + " -->"
+        // Silent failure - keep original text without error comments
       }
     },
   } as Hooks
@@ -42,8 +41,8 @@ function formatMarkdownTables(text: string): string {
       if (isValidTable(tableLines)) {
         result.push(...formatTable(tableLines))
       } else {
+        // Silent failure - keep original table without error comments
         result.push(...tableLines)
-        result.push("<!-- table not formatted: invalid structure -->")
       }
     } else {
       result.push(line)


### PR DESCRIPTION
## Summary

- Remove HTML error comments (`<!-- table formatting failed -->` and `<!-- table not formatted -->`) that were appearing in rendered output
- Silent failure now keeps original table content without adding visible error messages

## Problem

The error comments were being rendered as visible text in OpenCode's output, making it appear as if the plugin was broken when it was actually working correctly. Users would see messages like:

```
<!-- table not formatted: invalid structure -->
```

This was confusing and cluttered the output.

## Solution

Changed error handling to silently keep the original table content when:
1. An exception is thrown during formatting
2. The table structure is invalid

This provides a cleaner user experience - tables that can't be formatted simply remain unformatted, without any visible error messages.

## Testing

Tested with various table types:
- Simple tables ✅
- Tables with markdown links ✅  
- Tables with bold/italic/code formatting ✅