### PR TITLE
fix: add support for underscore italic/bold, subscript, and superscript

### DIFF
--- a/index.test.ts
+++ b/index.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test"
+import { formatMarkdownTables } from "./index"
+
+/**
+ * These tests verify width calculation for markdown that gets "concealed" in OpenCode.
+ * 
+ * IMPORTANT: The raw output may look misaligned, but that's intentional!
+ * In concealment mode, markdown symbols (**, *, _, ~, ^, etc.) are hidden visually.
+ * The formatter calculates column widths based on VISUAL width, not raw character count.
+ * 
+ * Example: `_Italic_` is 8 raw chars but displays as "Italic" (6 chars) when concealed.
+ * So the column is padded to width 6, making the raw text appear to overflow.
+ * When viewed in OpenCode with concealment ON, the columns align perfectly.
+ */
+
+describe("formatMarkdownTables", () => {
+  describe("markdown concealment - underscore styles", () => {
+    test("calculates correct width for _italic_", () => {
+      const input = `
+| Style | Example |
+|-------|---------|
+| _Italic_ | text |
+`.trim()
+
+      expect(formatMarkdownTables(input)).toMatchInlineSnapshot(`
+        "| Style  | Example |
+        | ------ | ------- |
+        | _Italic_ | text    |"
+      `)
+    })
+
+    test("calculates correct width for __bold__", () => {
+      const input = `
+| Style | Example |
+|-------|---------|
+| __Bold__ | text |
+`.trim()
+
+      expect(formatMarkdownTables(input)).toMatchInlineSnapshot(`
+        "| Style | Example |
+        | ----- | ------- |
+        | __Bold__  | text    |"
+      `)
+    })
+
+    test("calculates correct width for **_bold italic_**", () => {
+      const input = `
+| Style | Example |
+|-------|---------|
+| **_Mixed_** | text |
+`.trim()
+
+      expect(formatMarkdownTables(input)).toMatchInlineSnapshot(`
+        "| Style | Example |
+        | ----- | ------- |
+        | **_Mixed_** | text    |"
+      `)
+    })
+  })
+
+  describe("markdown concealment - subscript and superscript", () => {
+    test("calculates correct width for ~subscript~", () => {
+      const input = `
+| Style | Example |
+|-------|---------|
+| H~2~O | text |
+`.trim()
+
+      expect(formatMarkdownTables(input)).toMatchInlineSnapshot(`
+        "| Style | Example |
+        | ----- | ------- |
+        | H~2~O   | text    |"
+      `)
+    })
+
+    test("calculates correct width for ^superscript^", () => {
+      const input = `
+| Style | Example |
+|-------|---------|
+| E=mc^2^ | text |
+`.trim()
+
+      expect(formatMarkdownTables(input)).toMatchInlineSnapshot(`
+        "| Style | Example |
+        | ----- | ------- |
+        | E=mc^2^ | text    |"
+      `)
+    })
+  })
+})

--- a/index.ts
+++ b/index.ts
@@ -22,7 +22,7 @@ export const FormatTables: Plugin = async () => {
   } as Hooks
 }
 
-function formatMarkdownTables(text: string): string {
+export function formatMarkdownTables(text: string): string {
   const lines = text.split("\n")
   const result: string[] = []
   let i = 0
@@ -180,9 +180,14 @@ function getStringWidth(text: string): number {
     previousText = visualText
     visualText = visualText
       .replace(/\*\*\*(.+?)\*\*\*/g, "$1") // ***bold+italic*** -> text
+      .replace(/___(.+?)___/g, "$1") // ___bold+italic___ -> text
       .replace(/\*\*(.+?)\*\*/g, "$1") // **bold** -> bold
+      .replace(/__(.+?)__/g, "$1") // __bold__ -> bold
       .replace(/\*(.+?)\*/g, "$1") // *italic* -> italic
+      .replace(/_(.+?)_/g, "$1") // _italic_ -> italic
       .replace(/~~(.+?)~~/g, "$1") // ~~strike~~ -> strike
+      .replace(/~(.+?)~/g, "$1") // ~subscript~ -> subscript
+      .replace(/\^(.+?)\^/g, "$1") // ^superscript^ -> superscript
       .replace(/!\[([^\]]*)\]\(([^)]+)\)/g, "$1") // ![alt](url) -> alt (OpenTUI shows only alt text)
       .replace(/\[([^\]]+)\]\(([^)]+)\)/g, "$1 ($2)") // [text](url) -> text (url)
   }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "README.md"
   ],
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "bun test"
   },
   "peerDependencies": {
     "@opencode-ai/plugin": ">=0.13.7"


### PR DESCRIPTION
## Summary

This PR adds missing markdown stripping patterns for width calculations in concealment mode:

- `_italic_` and `__bold__` (underscore variants)
- `___bold+italic___` (underscore variant)  
- `~subscript~` (single tilde)
- `^superscript^` (caret)

## Problem

When using markdown like `**_Bold Italic_**` or `Sub~script~`, the underscore and single-tilde patterns were not being stripped during width calculation. This caused misaligned table columns because the concealed characters were still being counted toward the display width.

<img width="1306" height="609" alt="Screenshot 2026-01-29 at 7 33 49 PM" src="https://github.com/user-attachments/assets/1613abbc-83ed-41e1-9fee-7674b8bbad1f" />


## Example

Before this fix, a table with these cells would be misaligned:

```md
| Style | Example |
|-------|---------|
| **_Bold Italic_** | combined |
| Sub~script~ | H~2~O |
```

## Changes

Added 5 new regex patterns to `getStringWidth()` in the markdown stripping loop:

```typescript
.replace(/___(.+?)___/g, "$1") // ___bold+italic___ -> text
.replace(/__(.+?)__/g, "$1")   // __bold__ -> bold
.replace(/_(.+?)_/g, "$1")     // _italic_ -> italic
.replace(/~(.+?)~/g, "$1")     // ~subscript~ -> subscript
.replace(/\^(.+?)\^/g, "$1")   // ^superscript^ -> superscript
```